### PR TITLE
Implement draft version of type text

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,7 @@ Example:
     question2: {
       question: 'Question 2',
       id: 'question-2',
-      type: 'list',
-      options: [
-        { name: 'Answer 1', value: 'answer-1' },
-        { name: 'Answer 2', value: 'answer-2' },
-      ]
+      type: 'text',
     },
     question3: {
       question: 'Question 3',
@@ -222,7 +218,7 @@ The `Component` class provides a number of methods to use when creating your inp
 
 A number of `keyPress` events can be handled. The only manditory handler is for `onKeyEnter`. This must resolve the component and clear the screen for the next question. The following event handlers are available:
 
-- **onKeyEnter** 
+- **onKeyEnter**
 
 - **onKeyUp**
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ Right now Wizard includes the following input types:
   - options (Array of Options)
 - Use it by selecting `listToggle` in your questions object: `type: 'listToggle'`
 
+#### `Text` - A simple input, submit with `Enter`
+
+- Use it by selecting `text` in your questions object: `type: 'text'`
+
 ## Custom Inputs
 
 You can make your very own personalized inputs if the ones provided don't suit your needs. A `Component` class is available by importing it -  `import { Component } from 'wizard`. It provides a number of methods and events to extend wizard however you wish.

--- a/example/src/questions.js
+++ b/example/src/questions.js
@@ -7,6 +7,16 @@ export default {
     { name: 'Custom', value: 'custom', then: 'custom' },
   ],
   then: {
+    email: {
+      question: 'Type in your email:',
+      id: 'email',
+      type: 'text',
+      then: {
+        question: 'Type in your login:',
+        id: 'login',
+        type: 'text',
+      },
+    },
     template: {
       question: 'Pick a template:',
       id: 'template',
@@ -47,9 +57,16 @@ export default {
               id: 'useReact',
               type: 'list',
               options: [
-                { name: 'Yes', value: 'yes' },
-                { name: 'No', value: 'no' },
+                { name: 'Yes', value: 'yes', then: 'askTemplateName' },
+                { name: 'No', value: 'no', then: 'askTemplateName' },
               ],
+              then: {
+                askTemplateName: {
+                  question: 'What will be the name of this configuration?',
+                  id: 'templateName',
+                  type: 'text',
+                },
+              },
             },
           },
         },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "watch:example": "babel example/src -d example/build -w",
     "build:example": "babel example/src -d example/build",
     "precommit": "lint-staged",
+    "format": "prettier --write ./**/**/*.js",
     "prepare": "npm run build"
   },
   "repository": {

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -1,0 +1,66 @@
+import Component from './Component';
+
+const ESC_UTF16_CODE = 127;
+const ARROWS_UTF16_CODE = 27;
+
+class Text extends Component {
+  constructor(question, styles) {
+    super();
+
+    this.styles = styles;
+    this.question = question.question;
+    this.answer = '';
+  }
+
+  handleKeyPress(key) {
+    if (key.charCodeAt(0) === ESC_UTF16_CODE) {
+      this.answer = this.answer.slice(0, this.answer.length - 1);
+    } else if (key.charCodeAt(0) === ARROWS_UTF16_CODE) {
+      // we don't need answers like '\u001b[A'
+      return;
+    } else {
+      if (key === '\t') {
+        key = ' ';
+      }
+
+      this.answer += key.toString();
+    }
+
+    this.update();
+  }
+
+  update() {
+    this.write(this.ansi.eraseLine);
+    this.write(
+      this.styles.caret.color(
+        this.styles.caret.icon.padStart(
+          this.styles.caret.paddingLeft + 1,
+          ' '.repeat(this.styles.caret.paddingLeft),
+        ),
+      ) +
+        ' '.repeat(this.styles.caret.paddingRight) +
+        this.styles.list.selectedColor(this.answer),
+    );
+  }
+
+  init() {
+    return new Promise(async resolve => {
+      this._handleKeyPress = this.handleKeyPress.bind(this);
+
+      this.onKeyEnter = () => {
+        process.stdin.removeListener('data', this._handleKeyPress);
+        this.clear();
+        resolve({
+          value: this.answer,
+        });
+      };
+
+      this.initialize(this.question);
+      this.write(this.ansi.cursorShow);
+      this.write(this.ansi.cursorTo(this.styles.caret.paddingLeft + 2));
+      process.stdin.addListener('data', this._handleKeyPress);
+    });
+  }
+}
+
+export default Text;

--- a/src/components/Wizard.js
+++ b/src/components/Wizard.js
@@ -4,6 +4,7 @@ import Component from './Component';
 
 import list from './List';
 import listToggle from './ListToggle';
+import text from './Text';
 
 class Wizard extends Component {
   constructor(steps, styles, components) {
@@ -40,6 +41,7 @@ class Wizard extends Component {
     this.components = {
       list,
       listToggle,
+      text,
       ...components,
     };
 
@@ -78,7 +80,10 @@ class Wizard extends Component {
           const response = await component.init();
           this.selections[section.id] = response.value;
 
-          if (section.then && section.then[response.then]) {
+          if (
+            (section.then && section.then[response.then]) ||
+            (section.type === 'text' && section.then)
+          ) {
             try {
               const data = await this.traverse(section.then[response.then]);
               resolve(data);


### PR DESCRIPTION
- Implemented a new type — text;
- Changed README due to the new type;
- Changed the example.

Important:
I didn't manage to implement changing text with cursor moving. Thus, a user can only type in and clear last characters with Backspace. But cannot use arrows to fix a character somewhere inside a word.